### PR TITLE
Animate userquake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Go web client for P2PQuake, a Japanese earthquake monitoring system. The application displays earthquake information, tsunami warnings, and user-reported earthquake sensing data from MongoDB collections.
+
+## Architecture
+
+- **Backend**: Go HTTP server with MongoDB integration
+- **Frontend**: Server-side rendered HTML templates with TailwindCSS
+- **Data Sources**: Two MongoDB collections - `whole` (general events) and `jma` (Japan Meteorological Agency data)
+- **Event Types**: 
+  - Code 551/552/556: Official earthquake/tsunami/EEW data
+  - Code 9611: User-reported earthquake sensing data
+
+### Key Components
+
+- `main.go`: HTTP server setup with MongoDB connection
+- `handler/`: HTTP request handlers for index and item pages
+- `model/`: Data conversion from MongoDB BSON to Go structs
+- `renderer/`: HTML template rendering engine
+- `template/`: HTML templates for different event types
+- `static/`: CSS and image assets
+
+### Data Processing
+
+The earthquake model includes complex logic for:
+- Scale prioritization (震度5弱以上と推定 gets lower priority than actual 震度5弱)
+- Point deduplication by city/municipality
+- Prefecture-based grouping
+- Time formatting for Japanese locale
+
+## Development Commands
+
+### Build and Run
+```bash
+go run main.go
+```
+
+### CSS Generation
+```bash
+./generate.sh
+# or manually:
+npx tailwindcss -i template/input.css -o static/main.css
+```
+
+### Docker Build
+```bash
+docker build -t web-client .
+```
+
+## Environment Variables
+
+Required for runtime:
+- `MONGODB_URL`: MongoDB connection string
+- `DATABASE`: MongoDB database name  
+- `COLLECTION`: MongoDB collection name for general events
+- `GTM_CONTAINER_ID`: Google Tag Manager container ID (optional)
+
+## Template System
+
+Templates use Go's html/template with custom functions:
+- `date`: Current timestamp in Japanese format
+- `gtag`: Google Tag Manager container ID
+
+Templates are organized by event type (earthquake.html, tsunami.html, eew.html, userquake.html) with a shared layout.html.

--- a/handler/item.go
+++ b/handler/item.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 
@@ -41,4 +42,93 @@ func (s *Service) ItemHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	// w.Header().Set("Cache-Control", "no-cache")
 	w.Write([]byte(html))
+}
+
+func (s *Service) TimeseriesHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	log.Printf("TimeseriesHandler called with ID: %s", id)
+	
+	if id == "" {
+		log.Printf("Empty ID received")
+		ResponseError(w, http.StatusBadRequest, "Empty ID")
+		return
+	}
+	
+	// 指定されたIDに対応するstarted_atを取得
+	oid, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		log.Printf("Invalid ObjectID format: %s, error: %v", id, err)
+		ResponseError(w, http.StatusBadRequest, "Invalid ID format")
+		return
+	}
+
+	// 最初のレコードを取得してstarted_atを確認
+	var firstItem bson.M
+	err = s.Whole.FindOne(context.TODO(), bson.M{"_id": oid}).Decode(&firstItem)
+	if err != nil {
+		log.Printf("Item not found for ID: %s, error: %v", id, err)
+		ResponseError(w, http.StatusNotFound, "Item not found")
+		return
+	}
+
+	code, ok := firstItem["code"]
+	log.Printf("Found item with code: %v (type: %T)", code, code)
+	
+	// コードの型に応じて比較
+	var codeInt int
+	switch v := code.(type) {
+	case int:
+		codeInt = v
+	case int32:
+		codeInt = int(v)
+	case int64:
+		codeInt = int(v)
+	case float64:
+		codeInt = int(v)
+	default:
+		log.Printf("Unexpected code type: %T, value: %v", code, code)
+		ResponseError(w, http.StatusBadRequest, "Invalid code type")
+		return
+	}
+	
+	if !ok || codeInt != 9611 {
+		log.Printf("Not a userquake event, code: %v (int: %d)", code, codeInt)
+		ResponseError(w, http.StatusBadRequest, "Not a userquake event")
+		return
+	}
+	
+	log.Printf("Confirmed userquake event with code: %d", codeInt)
+
+	startedAt, ok := firstItem["started_at"].(string)
+	if !ok {
+		log.Printf("Invalid started_at field: %v", firstItem["started_at"])
+		ResponseError(w, http.StatusInternalServerError, "Invalid started_at")
+		return
+	}
+	log.Printf("Found started_at: %s", startedAt)
+
+	// 同じstarted_atを持つ全てのレコードを取得
+	opts := options.FindOptions{Sort: bson.D{{"updated_at", 1}}}
+	cursor, err := s.Whole.Find(
+		context.TODO(),
+		bson.M{
+			"code":       9611,
+			"started_at": startedAt,
+		}, &opts)
+	if err != nil {
+		log.Printf("Database find error: %v", err)
+		ResponseError(w, http.StatusInternalServerError, "Database error")
+		return
+	}
+
+	var items []bson.M
+	if err = cursor.All(context.TODO(), &items); err != nil {
+		log.Printf("Database cursor error: %v", err)
+		ResponseError(w, http.StatusInternalServerError, "Database error")
+		return
+	}
+
+	log.Printf("Found %d timeseries items for started_at: %s", len(items), startedAt)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	http.HandleFunc("GET /", service.IndexHandler)
 	http.HandleFunc("GET /{id}", service.ItemHandler)
+	http.HandleFunc("GET /api/timeseries/{id}", service.TimeseriesHandler)
 	http.Handle("GET /static/", oneDayCache(http.StripPrefix("/static/", http.FileServer(http.Dir("static")))))
 
 	http.ListenAndServe(":8080", nil)

--- a/static/userquake.js
+++ b/static/userquake.js
@@ -1,0 +1,336 @@
+function initUserquakeTimeline(objectId) {
+  const userquakeContainer = document.querySelector(`[data-userquake-id="${objectId}"]`);
+  if (!userquakeContainer) return;
+
+  const playBtn = userquakeContainer.querySelector('.timeline-play-btn');
+  const slider = userquakeContainer.querySelector('.timeline-slider');
+  const speedSelect = userquakeContainer.querySelector('.timeline-speed-select');
+  const currentTimeDisplay = userquakeContainer.querySelector('.timeline-current-time');
+  const confidenceDisplay = userquakeContainer.querySelector('.timeline-confidence-display');
+  const timelineImage = userquakeContainer.querySelector('.timeline-image');
+  const timelineImageLink = userquakeContainer.querySelector('.timeline-image-link');
+
+  let timeseriesData = [];
+  let isPlaying = false;
+  let currentIndex = 0;
+  let animationInterval = null;
+  let startTime = null;
+  let totalDurationSeconds = 0;
+  let currentTimeSeconds = 0;
+  let preloadedImages = new Map();
+  let isPreloading = false;
+  let hasPreloaded = false;
+
+  fetch(`/api/timeseries/${objectId}`)
+    .then(response => response.json())
+    .then(data => {
+      timeseriesData = data;
+      if (data.length > 0) {
+        let confidenceStartTime = null;
+        for (let i = 0; i < data.length; i++) {
+          if (data[i].confidence && data[i].confidence > 0.9) {
+            confidenceStartTime = new Date(data[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+            break;
+          }
+        }
+        
+        startTime = confidenceStartTime || new Date(data[0].started_at.replace(/\//g, '-').replace(' ', 'T'));
+        const endTime = new Date(data[data.length - 1].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+        totalDurationSeconds = Math.ceil((endTime - startTime) / 1000);
+        
+        slider.min = 0;
+        slider.max = totalDurationSeconds;
+        slider.value = totalDurationSeconds;
+        
+        currentTimeSeconds = totalDurationSeconds;
+        currentIndex = data.length - 1;
+        updateDisplay();
+      }
+    })
+    .catch(error => console.error('Error loading timeseries data:', error));
+
+  function updateDisplay() {
+    if (timeseriesData.length === 0) return;
+    
+    currentIndex = findDataIndexForTime(currentTimeSeconds);
+    const current = timeseriesData[currentIndex];
+    if (!current) return;
+
+    const updatedAt = new Date(current.updated_at.replace(/\//g, '-').replace(' ', 'T'));
+    currentTimeDisplay.textContent = updatedAt.toLocaleTimeString('ja-JP');
+
+    const processed = processUserquakeData(current);
+    updateConfidenceDisplay(processed);
+    
+    updateImage(current);
+  }
+
+  function findDataIndexForTime(targetSeconds) {
+    if (!startTime || timeseriesData.length === 0) return 0;
+    
+    const targetTime = new Date(startTime.getTime() + targetSeconds * 1000);
+    
+    let bestIndex = 0;
+    let minDiff = Infinity;
+    
+    for (let i = 0; i < timeseriesData.length; i++) {
+      const dataTime = new Date(timeseriesData[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+      const diff = Math.abs(dataTime - targetTime);
+      
+      if (diff < minDiff) {
+        minDiff = diff;
+        bestIndex = i;
+      }
+      
+      if (dataTime > targetTime) {
+        break;
+      }
+    }
+    
+    return bestIndex;
+  }
+
+
+  function processUserquakeData(data) {
+    const areaConfidences = data.area_confidences || {};
+    
+    let max = 0.125;
+    for (const [area, conf] of Object.entries(areaConfidences)) {
+      if (conf.confidence > max) max = conf.confidence;
+    }
+    
+    const factor = 1.0 / max;
+    const normalizedAreas = [];
+    
+    for (const [area, conf] of Object.entries(areaConfidences)) {
+      const normalizedConf = conf.confidence * factor;
+      normalizedAreas.push({
+        area: area,
+        confidence: normalizedConf,
+        label: getConfidenceLabel(normalizedConf)
+      });
+    }
+    
+    normalizedAreas.sort((a, b) => b.confidence - a.confidence);
+    
+    const grouped = {};
+    for (const item of normalizedAreas) {
+      if (item.label === 'F') continue;
+      if (!grouped[item.label]) grouped[item.label] = [];
+      grouped[item.label].push(convertAreaCode(item.area));
+    }
+    
+    return grouped;
+  }
+
+  function getConfidenceLabel(confidence) {
+    if (confidence >= 0.8) return 'A';
+    if (confidence >= 0.6) return 'B';
+    if (confidence >= 0.4) return 'C';
+    if (confidence >= 0.2) return 'D';
+    if (confidence >= 0) return 'E';
+    return 'F';
+  }
+
+  function convertAreaCode(code) {
+    const areaMap = {
+      "900": "地域未設定", "901": "地域不明", "905": "日本以外",
+      "10": "北海道 石狩", "15": "北海道 渡島", "20": "北海道 檜山", "25": "北海道 後志",
+      "30": "北海道 空知", "35": "北海道 上川", "40": "北海道 留萌", "45": "北海道 宗谷",
+      "50": "北海道 網走", "55": "北海道 胆振", "60": "北海道 日高", "65": "北海道 十勝",
+      "70": "北海道 釧路", "75": "北海道 根室", "100": "青森津軽", "105": "青森三八上北",
+      "106": "青森下北", "110": "岩手沿岸北部", "111": "岩手沿岸南部", "115": "岩手内陸",
+      "120": "宮城北部", "125": "宮城南部", "130": "秋田沿岸", "135": "秋田内陸",
+      "140": "山形庄内", "141": "山形最上", "142": "山形村山", "143": "山形置賜",
+      "150": "福島中通り", "151": "福島浜通り", "152": "福島会津", "200": "茨城北部",
+      "205": "茨城南部", "210": "栃木北部", "215": "栃木南部", "220": "群馬北部",
+      "225": "群馬南部", "230": "埼玉北部", "231": "埼玉南部", "232": "埼玉秩父",
+      "240": "千葉北東部", "241": "千葉北西部", "242": "千葉南部", "250": "東京",
+      "255": "伊豆諸島北部", "260": "伊豆諸島南部", "265": "小笠原", "270": "神奈川東部",
+      "275": "神奈川西部", "300": "新潟上越", "301": "新潟中越", "302": "新潟下越",
+      "305": "新潟佐渡", "310": "富山東部", "315": "富山西部", "320": "石川能登",
+      "325": "石川加賀", "330": "福井嶺北", "335": "福井嶺南", "340": "山梨東部",
+      "345": "山梨中・西部", "350": "長野北部", "351": "長野中部", "355": "長野南部",
+      "400": "岐阜飛騨", "405": "岐阜美濃", "410": "静岡伊豆", "411": "静岡東部",
+      "415": "静岡中部", "416": "静岡西部", "420": "愛知東部", "425": "愛知西部",
+      "430": "三重北中部", "435": "三重南部", "440": "滋賀北部", "445": "滋賀南部",
+      "450": "京都北部", "455": "京都南部", "460": "大阪北部", "465": "大阪南部",
+      "470": "兵庫北部", "475": "兵庫南部", "480": "奈良", "490": "和歌山北部",
+      "495": "和歌山南部", "500": "鳥取東部", "505": "鳥取中・西部", "510": "島根東部",
+      "515": "島根西部", "514": "島根隠岐", "520": "岡山北部", "525": "岡山南部",
+      "530": "広島北部", "535": "広島南部", "540": "山口北部", "545": "山口中・東部",
+      "541": "山口西部", "550": "徳島北部", "555": "徳島南部", "560": "香川",
+      "570": "愛媛東予", "575": "愛媛中予", "576": "愛媛南予", "580": "高知東部",
+      "581": "高知中部", "582": "高知西部", "600": "福岡福岡", "601": "福岡北九州",
+      "602": "福岡筑豊", "605": "福岡筑後", "610": "佐賀北部", "615": "佐賀南部",
+      "620": "長崎北部", "625": "長崎南部", "630": "長崎壱岐・対馬", "635": "長崎五島",
+      "640": "熊本阿蘇", "641": "熊本熊本", "645": "熊本球磨", "646": "熊本天草・芦北",
+      "650": "大分北部", "651": "大分中部", "655": "大分西部", "656": "大分南部",
+      "660": "宮崎北部平野部", "661": "宮崎北部山沿い", "665": "宮崎南部平野部", "666": "宮崎南部山沿い",
+      "670": "鹿児島薩摩", "675": "鹿児島大隅", "680": "種子島・屋久島", "685": "鹿児島奄美",
+      "700": "沖縄本島北部", "701": "沖縄本島中南部", "702": "沖縄久米島", "705": "沖縄八重山",
+      "706": "沖縄宮古島", "710": "沖縄大東島"
+    };
+    return areaMap[code] || code;
+  }
+
+  function updateConfidenceDisplay(grouped) {
+    const labels = ['A', 'B', 'C', 'D', 'E'];
+    let html = '<div class="font-bold col-span-2">各地域の相対的な信頼度</div>';
+    
+    for (const label of labels) {
+      if (grouped[label] && grouped[label].length > 0) {
+        html += `<div><span class="text-sm x-confidence x-confidence-${label}">${label}</span></div>`;
+        html += `<div class="text-sm py-0.5">${grouped[label].join('、')}</div>`;
+      }
+    }
+    
+    html += '<div class="text-xs col-span-2">信頼度は揺れの強さを示すものではありません。「相対的な差」「分布の拡がり」に着目してご覧ください。</div>';
+    
+    confidenceDisplay.innerHTML = html;
+  }
+
+  function preloadImages() {
+    if (hasPreloaded || isPreloading) return Promise.resolve();
+    
+    isPreloading = true;
+    playBtn.textContent = '読み込み中...';
+    playBtn.disabled = true;
+    
+    const imagePromises = timeseriesData.map(data => {
+      return new Promise((resolve) => {
+        const objectId = extractObjectId(data);
+        
+        if (objectId) {
+          const imageUrl = `https://cdn.p2pquake.net/app/web/userquake?id=${objectId}&suffix=_trim`;
+          const img = new Image();
+          
+          img.onload = () => {
+            preloadedImages.set(objectId, img);
+            console.log('Preloaded image for objectId:', objectId);
+            resolve();
+          };
+          
+          img.onerror = () => {
+            console.warn('Failed to preload image for objectId:', objectId);
+            resolve();
+          };
+          
+          img.src = imageUrl;
+        } else {
+          resolve();
+        }
+      });
+    });
+    
+    return Promise.all(imagePromises).then(() => {
+      hasPreloaded = true;
+      isPreloading = false;
+      playBtn.textContent = '▶ 再生';
+      playBtn.disabled = false;
+    });
+  }
+
+  function extractObjectId(data) {
+    if (data._id) {
+      if (typeof data._id === 'string') {
+        return data._id;
+      } else if (data._id.$oid) {
+        return data._id.$oid;
+      } else if (data._id.toString) {
+        return data._id.toString();
+      }
+    }
+    return null;
+  }
+
+  function updateImage(data) {
+    const objectId = extractObjectId(data);
+    
+    if (objectId) {
+      const preloadedImg = preloadedImages.get(objectId);
+      if (preloadedImg) {
+        timelineImage.src = preloadedImg.src;
+        timelineImageLink.href = preloadedImg.src;
+      } else {
+        console.warn('Preloaded image not found for objectId:', objectId, 'Available keys:', Array.from(preloadedImages.keys()));
+        const imageUrl = `https://cdn.p2pquake.net/app/web/userquake?id=${objectId}&suffix=_trim`;
+        timelineImage.src = imageUrl;
+        timelineImageLink.href = imageUrl;
+      }
+    }
+  }
+
+  playBtn.addEventListener('click', () => {
+    if (isPreloading) return;
+    
+    if (isPlaying) {
+      stopAnimation();
+    } else {
+      if (!hasPreloaded) {
+        preloadImages().then(() => {
+          if (currentTimeSeconds >= totalDurationSeconds) {
+            currentTimeSeconds = 0;
+            slider.value = 0;
+            updateDisplay();
+          }
+          startAnimation();
+        });
+      } else {
+        if (currentTimeSeconds >= totalDurationSeconds) {
+          currentTimeSeconds = 0;
+          slider.value = 0;
+          updateDisplay();
+        }
+        startAnimation();
+      }
+    }
+  });
+
+  slider.addEventListener('input', (e) => {
+    stopAnimation();
+    currentTimeSeconds = parseInt(e.target.value);
+    updateDisplay();
+  });
+
+  speedSelect.addEventListener('change', () => {
+    if (isPlaying) {
+      stopAnimation();
+      startAnimation();
+    }
+  });
+
+  function startAnimation() {
+    if (timeseriesData.length <= 1) return;
+    
+    isPlaying = true;
+    playBtn.textContent = '■ 停止';
+    playBtn.dataset.playing = 'true';
+    
+    const speedMultiplier = parseFloat(speedSelect.value);
+    const baseInterval = 1000;
+    const actualInterval = baseInterval / speedMultiplier;
+    
+    animationInterval = setInterval(() => {
+      if (currentTimeSeconds >= totalDurationSeconds) {
+        stopAnimation();
+        return;
+      }
+      
+      currentTimeSeconds++;
+      slider.value = currentTimeSeconds;
+      updateDisplay();
+    }, actualInterval);
+  }
+
+  function stopAnimation() {
+    isPlaying = false;
+    playBtn.textContent = '▶ 再生';
+    playBtn.dataset.playing = 'false';
+    
+    if (animationInterval) {
+      clearInterval(animationInterval);
+      animationInterval = null;
+    }
+  }
+}

--- a/template/layout.html
+++ b/template/layout.html
@@ -14,6 +14,7 @@
     })(window,document,'script','dataLayer','{{ gtag }}');</script>
     <!-- End Google Tag Manager -->
     {{ end }}
+    <script src="./static/userquake.js"></script>
   </head>
   <body class="max-w-screen-lg mx-auto">
     {{ if ne gtag "" }}

--- a/template/userquake.html
+++ b/template/userquake.html
@@ -1,4 +1,4 @@
-<div class="border rounded bg-white">
+<div class="border rounded bg-white" data-userquake-id="{{ .ObjectID }}">
   <div class="px-2 py-1 bg-slate-100 border-b border-slate-100 flex justify-between items-center">
     <h3 class="flex gap-1 items-center text-lg font-bold">
       <img src="./static/images/userquake.svg" class="h-4 w-4" />
@@ -7,19 +7,46 @@
     <div class="text-sm">{{ .ShortTime }}</div>
   </div>
   <div class="p-2">
-    <a href="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim">
+    <a href="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim" class="timeline-image-link">
       <img
         src="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim"
-        class="w-full min-h-32 max-h-64 object-contain"
+        class="timeline-image w-full min-h-32 max-h-64 object-contain"
         loading="lazy"
       />
     </a>
   </div>
+  
+  {{/* Timeline Controls */}}
+  <div class="p-2 border-t bg-gray-50">
+    <div class="flex items-center gap-2 mb-2">
+      <button class="timeline-play-btn px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600" data-playing="false">
+        ▶ 再生
+      </button>
+      <span class="text-sm text-gray-600">
+        速度: <select class="timeline-speed-select text-sm border rounded px-1">
+          <option value="0.5">0.5x</option>
+          <option value="1" selected>1x</option>
+          <option value="1.5">1.5x</option>
+          <option value="2">2x</option>
+          <option value="3">3x</option>
+          <option value="5">5x</option>
+          <option value="10">10x</option>
+          <option value="20">20x</option>
+          <option value="30">30x</option>
+        </select>
+      </span>
+    </div>
+    <div class="flex items-center gap-2">
+      <input type="range" class="timeline-slider flex-1" min="0" max="100" value="100" />
+      <span class="timeline-current-time text-sm font-mono w-20 text-right">--:--:--</span>
+    </div>
+  </div>
+
   <div class="p-2 flex gap-2">
     <div class="font-bold">日時</div>
-    <div>{{ .StartTime }}～{{ .EndTime }}</div>
+    <div class="timeline-time-display">{{ .StartTime }}～{{ .EndTime }}</div>
   </div>
-  <div class="p-2 grid grid-cols-[2rem_minmax(0,_1fr)] gap-1">
+  <div class="p-2 grid grid-cols-[2rem_minmax(0,_1fr)] gap-1 timeline-confidence-display">
     <div class="font-bold col-span-2">各地域の相対的な信頼度</div>
     {{ range $_, $s := .AreaByConfidence }}
     <div><span class="text-sm x-confidence x-confidence-{{ $s.Confidence }}">{{ $s.Confidence }}</span></div>
@@ -30,3 +57,305 @@
     </div>
   </div>
 </div>
+
+<script>
+(function() {
+  const userquakeContainer = document.querySelector('[data-userquake-id="{{ .ObjectID }}"]');
+  if (!userquakeContainer) return;
+
+  const playBtn = userquakeContainer.querySelector('.timeline-play-btn');
+  const slider = userquakeContainer.querySelector('.timeline-slider');
+  const speedSelect = userquakeContainer.querySelector('.timeline-speed-select');
+  const currentTimeDisplay = userquakeContainer.querySelector('.timeline-current-time');
+  const timeDisplay = userquakeContainer.querySelector('.timeline-time-display');
+  const confidenceDisplay = userquakeContainer.querySelector('.timeline-confidence-display');
+  const timelineImage = userquakeContainer.querySelector('.timeline-image');
+  const timelineImageLink = userquakeContainer.querySelector('.timeline-image-link');
+
+  let timeseriesData = [];
+  let isPlaying = false;
+  let currentIndex = 0;
+  let animationInterval = null;
+  let startTime = null;
+  let endTime = null;
+  let totalDurationSeconds = 0;
+  let currentTimeSeconds = 0;
+
+  {{/* Load timeseries data */}}
+  fetch('/api/timeseries/{{ .ObjectID }}')
+    .then(response => response.json())
+    .then(data => {
+      timeseriesData = data;
+      if (data.length > 0) {
+        {{/* confidence が 0.9 を超えた最初の時点を開始時刻とする */}}
+        let confidenceStartTime = null;
+        for (let i = 0; i < data.length; i++) {
+          if (data[i].confidence && data[i].confidence > 0.9) {
+            confidenceStartTime = new Date(data[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+            break;
+          }
+        }
+        
+        {{/* confidence が 0.9 を超えなかった場合は従来通り started_at を使用 */}}
+        startTime = confidenceStartTime || new Date(data[0].started_at.replace(/\//g, '-').replace(' ', 'T'));
+        endTime = new Date(data[data.length - 1].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+        totalDurationSeconds = Math.ceil((endTime - startTime) / 1000);
+        
+        {{/* スライダーを秒単位に設定 */}}
+        slider.min = 0;
+        slider.max = totalDurationSeconds;
+        slider.value = totalDurationSeconds;
+        
+        {{/* 最新の時刻を設定 */}}
+        currentTimeSeconds = totalDurationSeconds;
+        currentIndex = data.length - 1;
+        updateDisplay();
+      }
+    })
+    .catch(error => console.error('Error loading timeseries data:', error));
+
+  function updateDisplay() {
+    if (timeseriesData.length === 0) return;
+    
+    {{/* 現在の時刻に基づいてデータインデックスを更新 */}}
+    currentIndex = findDataIndexForTime(currentTimeSeconds);
+    const current = timeseriesData[currentIndex];
+    if (!current) return;
+
+    {{/* Update current time display */}}
+    const updatedAt = new Date(current.updated_at.replace(/\//g, '-').replace(' ', 'T'));
+    currentTimeDisplay.textContent = updatedAt.toLocaleTimeString('ja-JP');
+
+    {{/* Update confidence display */}}
+    const processed = processUserquakeData(current);
+    updateConfidenceDisplay(processed);
+    
+    {{/* Update image */}}
+    updateImage(current);
+  }
+
+  function findDataIndexForTime(targetSeconds) {
+    if (!startTime || timeseriesData.length === 0) return 0;
+    
+    const targetTime = new Date(startTime.getTime() + targetSeconds * 1000);
+    
+    {{/* 指定時刻に最も近いデータを探す */}}
+    let bestIndex = 0;
+    let minDiff = Infinity;
+    
+    for (let i = 0; i < timeseriesData.length; i++) {
+      const dataTime = new Date(timeseriesData[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+      const diff = Math.abs(dataTime - targetTime);
+      
+      if (diff < minDiff) {
+        minDiff = diff;
+        bestIndex = i;
+      }
+      
+      {{/* 目標時刻を過ぎた場合は直前のデータを使用 */}}
+      if (dataTime > targetTime) {
+        break;
+      }
+    }
+    
+    return bestIndex;
+  }
+
+  function getCurrentTimeSeconds() {
+    if (!startTime || timeseriesData.length === 0) return 0;
+    
+    const currentTime = new Date(timeseriesData[currentIndex].updated_at.replace(/\//g, '-').replace(' ', 'T'));
+    return Math.floor((currentTime - startTime) / 1000);
+  }
+
+  function processUserquakeData(data) {
+    const areaConfidences = data.area_confidences || {};
+    
+    {{/* Normalize confidences */}}
+    let max = 0.125;
+    for (const [area, conf] of Object.entries(areaConfidences)) {
+      if (conf.confidence > max) max = conf.confidence;
+    }
+    
+    const factor = 1.0 / max;
+    const normalizedAreas = [];
+    
+    for (const [area, conf] of Object.entries(areaConfidences)) {
+      const normalizedConf = conf.confidence * factor;
+      normalizedAreas.push({
+        area: area,
+        confidence: normalizedConf,
+        label: getConfidenceLabel(normalizedConf)
+      });
+    }
+    
+    {{/* Sort by confidence */}}
+    normalizedAreas.sort((a, b) => b.confidence - a.confidence);
+    
+    {{/* Group by confidence label */}}
+    const grouped = {};
+    for (const item of normalizedAreas) {
+      if (item.label === 'F') continue;
+      if (!grouped[item.label]) grouped[item.label] = [];
+      grouped[item.label].push(convertAreaCode(item.area));
+    }
+    
+    return grouped;
+  }
+
+  function getConfidenceLabel(confidence) {
+    if (confidence >= 0.8) return 'A';
+    if (confidence >= 0.6) return 'B';
+    if (confidence >= 0.4) return 'C';
+    if (confidence >= 0.2) return 'D';
+    if (confidence >= 0) return 'E';
+    return 'F';
+  }
+
+  function convertAreaCode(code) {
+    const areaMap = {
+      "900": "地域未設定", "901": "地域不明", "905": "日本以外",
+      "10": "北海道 石狩", "15": "北海道 渡島", "20": "北海道 檜山", "25": "北海道 後志",
+      "30": "北海道 空知", "35": "北海道 上川", "40": "北海道 留萌", "45": "北海道 宗谷",
+      "50": "北海道 網走", "55": "北海道 胆振", "60": "北海道 日高", "65": "北海道 十勝",
+      "70": "北海道 釧路", "75": "北海道 根室", "100": "青森津軽", "105": "青森三八上北",
+      "106": "青森下北", "110": "岩手沿岸北部", "111": "岩手沿岸南部", "115": "岩手内陸",
+      "120": "宮城北部", "125": "宮城南部", "130": "秋田沿岸", "135": "秋田内陸",
+      "140": "山形庄内", "141": "山形最上", "142": "山形村山", "143": "山形置賜",
+      "150": "福島中通り", "151": "福島浜通り", "152": "福島会津", "200": "茨城北部",
+      "205": "茨城南部", "210": "栃木北部", "215": "栃木南部", "220": "群馬北部",
+      "225": "群馬南部", "230": "埼玉北部", "231": "埼玉南部", "232": "埼玉秩父",
+      "240": "千葉北東部", "241": "千葉北西部", "242": "千葉南部", "250": "東京",
+      "255": "伊豆諸島北部", "260": "伊豆諸島南部", "265": "小笠原", "270": "神奈川東部",
+      "275": "神奈川西部", "300": "新潟上越", "301": "新潟中越", "302": "新潟下越",
+      "305": "新潟佐渡", "310": "富山東部", "315": "富山西部", "320": "石川能登",
+      "325": "石川加賀", "330": "福井嶺北", "335": "福井嶺南", "340": "山梨東部",
+      "345": "山梨中・西部", "350": "長野北部", "351": "長野中部", "355": "長野南部",
+      "400": "岐阜飛騨", "405": "岐阜美濃", "410": "静岡伊豆", "411": "静岡東部",
+      "415": "静岡中部", "416": "静岡西部", "420": "愛知東部", "425": "愛知西部",
+      "430": "三重北中部", "435": "三重南部", "440": "滋賀北部", "445": "滋賀南部",
+      "450": "京都北部", "455": "京都南部", "460": "大阪北部", "465": "大阪南部",
+      "470": "兵庫北部", "475": "兵庫南部", "480": "奈良", "490": "和歌山北部",
+      "495": "和歌山南部", "500": "鳥取東部", "505": "鳥取中・西部", "510": "島根東部",
+      "515": "島根西部", "514": "島根隠岐", "520": "岡山北部", "525": "岡山南部",
+      "530": "広島北部", "535": "広島南部", "540": "山口北部", "545": "山口中・東部",
+      "541": "山口西部", "550": "徳島北部", "555": "徳島南部", "560": "香川",
+      "570": "愛媛東予", "575": "愛媛中予", "576": "愛媛南予", "580": "高知東部",
+      "581": "高知中部", "582": "高知西部", "600": "福岡福岡", "601": "福岡北九州",
+      "602": "福岡筑豊", "605": "福岡筑後", "610": "佐賀北部", "615": "佐賀南部",
+      "620": "長崎北部", "625": "長崎南部", "630": "長崎壱岐・対馬", "635": "長崎五島",
+      "640": "熊本阿蘇", "641": "熊本熊本", "645": "熊本球磨", "646": "熊本天草・芦北",
+      "650": "大分北部", "651": "大分中部", "655": "大分西部", "656": "大分南部",
+      "660": "宮崎北部平野部", "661": "宮崎北部山沿い", "665": "宮崎南部平野部", "666": "宮崎南部山沿い",
+      "670": "鹿児島薩摩", "675": "鹿児島大隅", "680": "種子島・屋久島", "685": "鹿児島奄美",
+      "700": "沖縄本島北部", "701": "沖縄本島中南部", "702": "沖縄久米島", "705": "沖縄八重山",
+      "706": "沖縄宮古島", "710": "沖縄大東島"
+    };
+    return areaMap[code] || code;
+  }
+
+  function updateConfidenceDisplay(grouped) {
+    const labels = ['A', 'B', 'C', 'D', 'E'];
+    let html = '<div class="font-bold col-span-2">各地域の相対的な信頼度</div>';
+    
+    for (const label of labels) {
+      if (grouped[label] && grouped[label].length > 0) {
+        html += `<div><span class="text-sm x-confidence x-confidence-${label}">${label}</span></div>`;
+        html += `<div class="text-sm py-0.5">${grouped[label].join('、')}</div>`;
+      }
+    }
+    
+    html += '<div class="text-xs col-span-2">信頼度は揺れの強さを示すものではありません。「相対的な差」「分布の拡がり」に着目してご覧ください。</div>';
+    
+    confidenceDisplay.innerHTML = html;
+  }
+
+  function updateImage(data) {
+    let objectId = null;
+    
+    
+    {{/* 様々なObjectID形式に対応 */}}
+    if (data._id) {
+      if (typeof data._id === 'string') {
+        objectId = data._id;
+      } else if (data._id.$oid) {
+        objectId = data._id.$oid;
+      } else if (data._id.toString) {
+        objectId = data._id.toString();
+      }
+    }
+    
+    
+    if (objectId) {
+      const imageUrl = `https://cdn.p2pquake.net/app/web/userquake?id=${objectId}&suffix=_trim`;
+      timelineImage.src = imageUrl;
+      timelineImageLink.href = imageUrl;
+    }
+  }
+
+  {{/* Event listeners */}}
+  playBtn.addEventListener('click', () => {
+    if (isPlaying) {
+      stopAnimation();
+    } else {
+      {{/* 末尾にいる場合は最初から再生 */}}
+      if (currentTimeSeconds >= totalDurationSeconds) {
+        currentTimeSeconds = 0;
+        slider.value = 0;
+        updateDisplay();
+      }
+      startAnimation();
+    }
+  });
+
+
+  slider.addEventListener('input', (e) => {
+    stopAnimation();
+    currentTimeSeconds = parseInt(e.target.value);
+    updateDisplay();
+  });
+
+  speedSelect.addEventListener('change', () => {
+    {{/* 再生中の場合は新しい速度で再開 */}}
+    if (isPlaying) {
+      stopAnimation();
+      startAnimation();
+    }
+  });
+
+  function startAnimation() {
+    if (timeseriesData.length <= 1) return;
+    
+    isPlaying = true;
+    playBtn.textContent = '⏸ 停止';
+    playBtn.dataset.playing = 'true';
+    
+    const speedMultiplier = parseFloat(speedSelect.value);
+    const baseInterval = 1000; {{/* 1秒ベース */}}
+    const actualInterval = baseInterval / speedMultiplier;
+    
+    animationInterval = setInterval(() => {
+      if (currentTimeSeconds >= totalDurationSeconds) {
+        stopAnimation();
+        return;
+      }
+      
+      {{/* 1秒進める */}}
+      currentTimeSeconds++;
+      slider.value = currentTimeSeconds;
+      updateDisplay();
+    }, actualInterval);
+  }
+
+  function stopAnimation() {
+    isPlaying = false;
+    playBtn.textContent = '▶ 再生';
+    playBtn.dataset.playing = 'false';
+    
+    if (animationInterval) {
+      clearInterval(animationInterval);
+      animationInterval = null;
+    }
+  }
+})();
+</script>

--- a/template/userquake.html
+++ b/template/userquake.html
@@ -8,35 +8,33 @@
   </div>
   <div class="p-2">
     <a href="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim" class="timeline-image-link">
-      <img
-        src="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim"
-        class="timeline-image w-full min-h-32 max-h-64 object-contain"
-        loading="lazy"
-      />
+      <img src="https://cdn.p2pquake.net/app/web/userquake?id={{ .ObjectID }}&suffix=_trim"
+        class="timeline-image w-full min-h-32 max-h-64 object-contain" loading="lazy" />
     </a>
   </div>
-  
+
   {{/* Timeline Controls */}}
-  <div class="p-2 border-t bg-gray-50">
-    <div class="flex items-center gap-2 mb-2">
-      <button class="timeline-play-btn px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600" data-playing="false">
+  <div class="p-2 border-t bg-gray-50 flex flex-col gap-2 md:gap-4 md:flex-row md:items-center">
+    <div class="flex items-center gap-2">
+      <button class="timeline-play-btn px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600"
+        data-playing="false">
         ▶ 再生
       </button>
       <span class="text-sm text-gray-600">
         速度: <select class="timeline-speed-select text-sm border rounded px-1">
           <option value="0.5">0.5x</option>
-          <option value="1" selected>1x</option>
+          <option value="1">1x</option>
           <option value="1.5">1.5x</option>
           <option value="2">2x</option>
           <option value="3">3x</option>
-          <option value="5">5x</option>
+          <option value="5" selected>5x</option>
           <option value="10">10x</option>
           <option value="20">20x</option>
           <option value="30">30x</option>
         </select>
       </span>
     </div>
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2 md:flex-grow">
       <input type="range" class="timeline-slider flex-1" min="0" max="100" value="100" />
       <span class="timeline-current-time text-sm font-mono w-20 text-right">--:--:--</span>
     </div>
@@ -59,303 +57,5 @@
 </div>
 
 <script>
-(function() {
-  const userquakeContainer = document.querySelector('[data-userquake-id="{{ .ObjectID }}"]');
-  if (!userquakeContainer) return;
-
-  const playBtn = userquakeContainer.querySelector('.timeline-play-btn');
-  const slider = userquakeContainer.querySelector('.timeline-slider');
-  const speedSelect = userquakeContainer.querySelector('.timeline-speed-select');
-  const currentTimeDisplay = userquakeContainer.querySelector('.timeline-current-time');
-  const timeDisplay = userquakeContainer.querySelector('.timeline-time-display');
-  const confidenceDisplay = userquakeContainer.querySelector('.timeline-confidence-display');
-  const timelineImage = userquakeContainer.querySelector('.timeline-image');
-  const timelineImageLink = userquakeContainer.querySelector('.timeline-image-link');
-
-  let timeseriesData = [];
-  let isPlaying = false;
-  let currentIndex = 0;
-  let animationInterval = null;
-  let startTime = null;
-  let endTime = null;
-  let totalDurationSeconds = 0;
-  let currentTimeSeconds = 0;
-
-  {{/* Load timeseries data */}}
-  fetch('/api/timeseries/{{ .ObjectID }}')
-    .then(response => response.json())
-    .then(data => {
-      timeseriesData = data;
-      if (data.length > 0) {
-        {{/* confidence が 0.9 を超えた最初の時点を開始時刻とする */}}
-        let confidenceStartTime = null;
-        for (let i = 0; i < data.length; i++) {
-          if (data[i].confidence && data[i].confidence > 0.9) {
-            confidenceStartTime = new Date(data[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
-            break;
-          }
-        }
-        
-        {{/* confidence が 0.9 を超えなかった場合は従来通り started_at を使用 */}}
-        startTime = confidenceStartTime || new Date(data[0].started_at.replace(/\//g, '-').replace(' ', 'T'));
-        endTime = new Date(data[data.length - 1].updated_at.replace(/\//g, '-').replace(' ', 'T'));
-        totalDurationSeconds = Math.ceil((endTime - startTime) / 1000);
-        
-        {{/* スライダーを秒単位に設定 */}}
-        slider.min = 0;
-        slider.max = totalDurationSeconds;
-        slider.value = totalDurationSeconds;
-        
-        {{/* 最新の時刻を設定 */}}
-        currentTimeSeconds = totalDurationSeconds;
-        currentIndex = data.length - 1;
-        updateDisplay();
-      }
-    })
-    .catch(error => console.error('Error loading timeseries data:', error));
-
-  function updateDisplay() {
-    if (timeseriesData.length === 0) return;
-    
-    {{/* 現在の時刻に基づいてデータインデックスを更新 */}}
-    currentIndex = findDataIndexForTime(currentTimeSeconds);
-    const current = timeseriesData[currentIndex];
-    if (!current) return;
-
-    {{/* Update current time display */}}
-    const updatedAt = new Date(current.updated_at.replace(/\//g, '-').replace(' ', 'T'));
-    currentTimeDisplay.textContent = updatedAt.toLocaleTimeString('ja-JP');
-
-    {{/* Update confidence display */}}
-    const processed = processUserquakeData(current);
-    updateConfidenceDisplay(processed);
-    
-    {{/* Update image */}}
-    updateImage(current);
-  }
-
-  function findDataIndexForTime(targetSeconds) {
-    if (!startTime || timeseriesData.length === 0) return 0;
-    
-    const targetTime = new Date(startTime.getTime() + targetSeconds * 1000);
-    
-    {{/* 指定時刻に最も近いデータを探す */}}
-    let bestIndex = 0;
-    let minDiff = Infinity;
-    
-    for (let i = 0; i < timeseriesData.length; i++) {
-      const dataTime = new Date(timeseriesData[i].updated_at.replace(/\//g, '-').replace(' ', 'T'));
-      const diff = Math.abs(dataTime - targetTime);
-      
-      if (diff < minDiff) {
-        minDiff = diff;
-        bestIndex = i;
-      }
-      
-      {{/* 目標時刻を過ぎた場合は直前のデータを使用 */}}
-      if (dataTime > targetTime) {
-        break;
-      }
-    }
-    
-    return bestIndex;
-  }
-
-  function getCurrentTimeSeconds() {
-    if (!startTime || timeseriesData.length === 0) return 0;
-    
-    const currentTime = new Date(timeseriesData[currentIndex].updated_at.replace(/\//g, '-').replace(' ', 'T'));
-    return Math.floor((currentTime - startTime) / 1000);
-  }
-
-  function processUserquakeData(data) {
-    const areaConfidences = data.area_confidences || {};
-    
-    {{/* Normalize confidences */}}
-    let max = 0.125;
-    for (const [area, conf] of Object.entries(areaConfidences)) {
-      if (conf.confidence > max) max = conf.confidence;
-    }
-    
-    const factor = 1.0 / max;
-    const normalizedAreas = [];
-    
-    for (const [area, conf] of Object.entries(areaConfidences)) {
-      const normalizedConf = conf.confidence * factor;
-      normalizedAreas.push({
-        area: area,
-        confidence: normalizedConf,
-        label: getConfidenceLabel(normalizedConf)
-      });
-    }
-    
-    {{/* Sort by confidence */}}
-    normalizedAreas.sort((a, b) => b.confidence - a.confidence);
-    
-    {{/* Group by confidence label */}}
-    const grouped = {};
-    for (const item of normalizedAreas) {
-      if (item.label === 'F') continue;
-      if (!grouped[item.label]) grouped[item.label] = [];
-      grouped[item.label].push(convertAreaCode(item.area));
-    }
-    
-    return grouped;
-  }
-
-  function getConfidenceLabel(confidence) {
-    if (confidence >= 0.8) return 'A';
-    if (confidence >= 0.6) return 'B';
-    if (confidence >= 0.4) return 'C';
-    if (confidence >= 0.2) return 'D';
-    if (confidence >= 0) return 'E';
-    return 'F';
-  }
-
-  function convertAreaCode(code) {
-    const areaMap = {
-      "900": "地域未設定", "901": "地域不明", "905": "日本以外",
-      "10": "北海道 石狩", "15": "北海道 渡島", "20": "北海道 檜山", "25": "北海道 後志",
-      "30": "北海道 空知", "35": "北海道 上川", "40": "北海道 留萌", "45": "北海道 宗谷",
-      "50": "北海道 網走", "55": "北海道 胆振", "60": "北海道 日高", "65": "北海道 十勝",
-      "70": "北海道 釧路", "75": "北海道 根室", "100": "青森津軽", "105": "青森三八上北",
-      "106": "青森下北", "110": "岩手沿岸北部", "111": "岩手沿岸南部", "115": "岩手内陸",
-      "120": "宮城北部", "125": "宮城南部", "130": "秋田沿岸", "135": "秋田内陸",
-      "140": "山形庄内", "141": "山形最上", "142": "山形村山", "143": "山形置賜",
-      "150": "福島中通り", "151": "福島浜通り", "152": "福島会津", "200": "茨城北部",
-      "205": "茨城南部", "210": "栃木北部", "215": "栃木南部", "220": "群馬北部",
-      "225": "群馬南部", "230": "埼玉北部", "231": "埼玉南部", "232": "埼玉秩父",
-      "240": "千葉北東部", "241": "千葉北西部", "242": "千葉南部", "250": "東京",
-      "255": "伊豆諸島北部", "260": "伊豆諸島南部", "265": "小笠原", "270": "神奈川東部",
-      "275": "神奈川西部", "300": "新潟上越", "301": "新潟中越", "302": "新潟下越",
-      "305": "新潟佐渡", "310": "富山東部", "315": "富山西部", "320": "石川能登",
-      "325": "石川加賀", "330": "福井嶺北", "335": "福井嶺南", "340": "山梨東部",
-      "345": "山梨中・西部", "350": "長野北部", "351": "長野中部", "355": "長野南部",
-      "400": "岐阜飛騨", "405": "岐阜美濃", "410": "静岡伊豆", "411": "静岡東部",
-      "415": "静岡中部", "416": "静岡西部", "420": "愛知東部", "425": "愛知西部",
-      "430": "三重北中部", "435": "三重南部", "440": "滋賀北部", "445": "滋賀南部",
-      "450": "京都北部", "455": "京都南部", "460": "大阪北部", "465": "大阪南部",
-      "470": "兵庫北部", "475": "兵庫南部", "480": "奈良", "490": "和歌山北部",
-      "495": "和歌山南部", "500": "鳥取東部", "505": "鳥取中・西部", "510": "島根東部",
-      "515": "島根西部", "514": "島根隠岐", "520": "岡山北部", "525": "岡山南部",
-      "530": "広島北部", "535": "広島南部", "540": "山口北部", "545": "山口中・東部",
-      "541": "山口西部", "550": "徳島北部", "555": "徳島南部", "560": "香川",
-      "570": "愛媛東予", "575": "愛媛中予", "576": "愛媛南予", "580": "高知東部",
-      "581": "高知中部", "582": "高知西部", "600": "福岡福岡", "601": "福岡北九州",
-      "602": "福岡筑豊", "605": "福岡筑後", "610": "佐賀北部", "615": "佐賀南部",
-      "620": "長崎北部", "625": "長崎南部", "630": "長崎壱岐・対馬", "635": "長崎五島",
-      "640": "熊本阿蘇", "641": "熊本熊本", "645": "熊本球磨", "646": "熊本天草・芦北",
-      "650": "大分北部", "651": "大分中部", "655": "大分西部", "656": "大分南部",
-      "660": "宮崎北部平野部", "661": "宮崎北部山沿い", "665": "宮崎南部平野部", "666": "宮崎南部山沿い",
-      "670": "鹿児島薩摩", "675": "鹿児島大隅", "680": "種子島・屋久島", "685": "鹿児島奄美",
-      "700": "沖縄本島北部", "701": "沖縄本島中南部", "702": "沖縄久米島", "705": "沖縄八重山",
-      "706": "沖縄宮古島", "710": "沖縄大東島"
-    };
-    return areaMap[code] || code;
-  }
-
-  function updateConfidenceDisplay(grouped) {
-    const labels = ['A', 'B', 'C', 'D', 'E'];
-    let html = '<div class="font-bold col-span-2">各地域の相対的な信頼度</div>';
-    
-    for (const label of labels) {
-      if (grouped[label] && grouped[label].length > 0) {
-        html += `<div><span class="text-sm x-confidence x-confidence-${label}">${label}</span></div>`;
-        html += `<div class="text-sm py-0.5">${grouped[label].join('、')}</div>`;
-      }
-    }
-    
-    html += '<div class="text-xs col-span-2">信頼度は揺れの強さを示すものではありません。「相対的な差」「分布の拡がり」に着目してご覧ください。</div>';
-    
-    confidenceDisplay.innerHTML = html;
-  }
-
-  function updateImage(data) {
-    let objectId = null;
-    
-    
-    {{/* 様々なObjectID形式に対応 */}}
-    if (data._id) {
-      if (typeof data._id === 'string') {
-        objectId = data._id;
-      } else if (data._id.$oid) {
-        objectId = data._id.$oid;
-      } else if (data._id.toString) {
-        objectId = data._id.toString();
-      }
-    }
-    
-    
-    if (objectId) {
-      const imageUrl = `https://cdn.p2pquake.net/app/web/userquake?id=${objectId}&suffix=_trim`;
-      timelineImage.src = imageUrl;
-      timelineImageLink.href = imageUrl;
-    }
-  }
-
-  {{/* Event listeners */}}
-  playBtn.addEventListener('click', () => {
-    if (isPlaying) {
-      stopAnimation();
-    } else {
-      {{/* 末尾にいる場合は最初から再生 */}}
-      if (currentTimeSeconds >= totalDurationSeconds) {
-        currentTimeSeconds = 0;
-        slider.value = 0;
-        updateDisplay();
-      }
-      startAnimation();
-    }
-  });
-
-
-  slider.addEventListener('input', (e) => {
-    stopAnimation();
-    currentTimeSeconds = parseInt(e.target.value);
-    updateDisplay();
-  });
-
-  speedSelect.addEventListener('change', () => {
-    {{/* 再生中の場合は新しい速度で再開 */}}
-    if (isPlaying) {
-      stopAnimation();
-      startAnimation();
-    }
-  });
-
-  function startAnimation() {
-    if (timeseriesData.length <= 1) return;
-    
-    isPlaying = true;
-    playBtn.textContent = '⏸ 停止';
-    playBtn.dataset.playing = 'true';
-    
-    const speedMultiplier = parseFloat(speedSelect.value);
-    const baseInterval = 1000; {{/* 1秒ベース */}}
-    const actualInterval = baseInterval / speedMultiplier;
-    
-    animationInterval = setInterval(() => {
-      if (currentTimeSeconds >= totalDurationSeconds) {
-        stopAnimation();
-        return;
-      }
-      
-      {{/* 1秒進める */}}
-      currentTimeSeconds++;
-      slider.value = currentTimeSeconds;
-      updateDisplay();
-    }, actualInterval);
-  }
-
-  function stopAnimation() {
-    isPlaying = false;
-    playBtn.textContent = '▶ 再生';
-    playBtn.dataset.playing = 'false';
-    
-    if (animationInterval) {
-      clearInterval(animationInterval);
-      animationInterval = null;
-    }
-  }
-})();
+  initUserquakeTimeline('{{ .ObjectID }}');
 </script>


### PR DESCRIPTION
プロンプト:

```
"Code 9611 について、何らかの集約処理をしているはずですが、どういった処理をしているか調べてください"
"started_at フィールドをキーにしているということは、時系列の変化がわかると考えてよいですか。"
"つまり、 started_at をキーにして、 updated_at と組み合わせると時系列変化がわかるということですか。"
"時系列変化をアニメーション表示できるようにしてください。デフォルトでは最新の状態を表示し、スライダーやスタートボタンなど で時系列変化が確認できるようにしてください。"
"go run main.go するとすぐに終了しています。修正してください"
"HTTP 400 エラーが出て、 時系列データを取得する API が機能していないようです。"
"コンソールに次のような内容が出力されました。 \n``` \n2025/06/14 21:25:40 TimeseriesHandler called with ID: 684a0f84d4f02d90ea721a49\n2025/06/14 21:25:40 Found item with code: 9611\n2025/06/14 21:25:40 Not a userquake event, code: 9611 \n```"
"動作しました。"
"フロントエンドの速度調整について、速度を逆にしてください。 0.5x が遅く、 2x が早くなるようにしてください。また、 30x までバリエーションを追加してください。 \nさらに、信頼度表示だけでなく、画像も更新するようにしてください。"
"画像が更新されないようです。"
"追加で以下の変更をお願いします。 \n1. 末尾で再生ボタンを押したとき、最初から再生してください \n2. 速度を変更したら、すぐ 反映してください"
"スライダーについて、情報ごとに1刻みではなく、1秒ごとに1刻みとするようにしてください"
"アニメーション再生すると、情報ごとに進んでしまいます。1秒ごとに進むようにしてください"
"Code 9611 のアニメーションについて、 confidence が 0.9 を超えた時点から表示するようにしてください。"
"戻してください。"
"アニメーションの開始時刻について、 started_at ではなく、 confidence が 0.9 を超えた時点とするよう変更してください"
"アニメーションの開始時刻について、 started_at ではなく、 confidence が 0.9 を超えた最初の時刻とするよう変更してください"
"area_confidences ではなく、ルートの confidence が 0.9 を超えた場合としてください"
"userquake.html は純粋な HTML なのか、そうでないのか調べてください"
"それでは、HTMLのコメントが外部（パブリック）に出ないよう、テンプレートファイルのコメントに書き換えてください"
"JavaScript のコメントもテンプレートコメントにしてください"
"リセットボタンは削除してください。また、デバッグログの出力も削除してください。"
"このサービスは静的ファイル(CSSなど)をどのように提供しているか調べてください"
"userquake.html の JavaScript について、複数回レンダーすると無駄が多いため、静的ファイル化するなどして共通化できますか。"
"アニメーション表示中の画像表示について、低速回線では読み込めないことが多いです。なぜですか。"
"画像のプリロードを実装してください。ただし、再生ボタンをはじめて押したタイミングでプリロードしてください。"
"プリロード完了している場合、スライダーを手動で動かしたときもプリロード済み画像が使われますか？"
"確認しましたが、途中からプリロード画像が使われていないか、失われているような気がします。なぜでしょうか"
"すべてプリロードできていますが、ブラウザがリクエストを発行してしまうようです。"
"未使用の変数や関数があれば削除してください。"
```